### PR TITLE
修改gitlab/traefik-gitlab.yml以适配新版本

### DIFF
--- a/gitlab/traefik-gitlab.yml
+++ b/gitlab/traefik-gitlab.yml
@@ -1,4 +1,5 @@
-apiVersion: extensions/v1beta1
+#apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gitlab
@@ -10,7 +11,10 @@ spec:
   - host: gitlab.xxx.net
     http:
       paths:
-      - backend:
-          serviceName: gitlab
-          servicePort: 80
-   
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gitlab
+            port:
+              number: 80


### PR DESCRIPTION
修改gitlab/traefik-gitlab.yml以适配新版本。
extensions/v1beta1现已被弃用。